### PR TITLE
Feature/test framework

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+DJANGO_SETTINGS_MODULE=test_settings
+django_find_project = false
+# enable the -s option to disable output capture
+# addopts = -s

--- a/runtests.py
+++ b/runtests.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+import os
+import sys
+
+os.environ['DJANGO_SETTINGS_MODULE'] = 'test_settings'
+
+import django
+from django.conf import settings
+from django.test.utils import get_runner
+
+
+def runtests():
+    try:
+        django.setup()
+    except AttributeError:
+        pass
+    TestRunner = get_runner(settings)
+    test_runner = TestRunner()
+    failures = test_runner.run_tests(["tests"])
+    sys.exit(bool(failures))
+
+if __name__ == '__main__':
+    runtests()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[aliases]
-test=pytest

--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,7 @@ setup(
     license = "MIT",
     keywords = "django angular interface",
     url = "https://zagaran.com",
-    setup_requires = ['pytest-runner',],
-    tests_require = ['pytest', 'pytest-django'],
+    test_suite="runtests.runtests",
     install_requires = ["django >= 1.9"],
     classifiers = [
                  "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     keywords = "django angular interface",
     url = "https://zagaran.com",
     setup_requires = ['pytest-runner',],
-    tests_require = ['pytest',],
+    tests_require = ['pytest', 'pytest-django'],
     install_requires = ["django >= 1.9"],
     classifiers = [
                  "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,8 @@ setup(
     license = "MIT",
     keywords = "django angular interface",
     url = "https://zagaran.com",
+    setup_requires = ['pytest-runner',],
+    tests_require = ['pytest',],
     install_requires = ["django >= 1.9"],
     classifiers = [
                  "Development Status :: 4 - Beta",

--- a/silica/django_app/templatetags/silica.py
+++ b/silica/django_app/templatetags/silica.py
@@ -46,7 +46,7 @@ def angular_model(model, angular_model_name, extra_params={}):
                 model_dict["fields"][field] = str(val)
             if field in m2m_fields:
                 model_dict["fields"][field] = map(str, val)
-        ret += "window.%s = %s;\n" % (angular_model_name, json.dumps(model_dict))
+        ret += "window.%s = %s;\n" % (angular_model_name, json.dumps(model_dict, sort_keys=True))
         # adds converter for datetime fields
         for field in model.READABLE_ATTRS(type_filter=models.DateField):
             # DateTimeFields are instances of DateFields

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,0 +1,29 @@
+
+# minimal Django config for running tests
+
+INSTALLED_APPS = (
+    'silica.django_app',
+    'tests',
+)
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'builtins': [
+                'silica.django_app.templatetags.silica',
+                'django.contrib.staticfiles.templatetags.staticfiles',
+            ],
+        },
+    },
+]
+
+SECRET_KEY = 'abcde12345'
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': 'testdatabase',
+    }
+}

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -106,9 +106,10 @@ class AngularModelTagTests(TagHelper):
         thingy = SilicaModelThingy(name="Carl Perkins")
         template = "{% angular_model model model_name params %}"
         context = {'model_name': 'carl', 'model': thingy}
-        output = (u'<script>\nwindow.carl = {"pk": null, "model": '
-                  u'"tests.silicamodelthingy", "fields": {"created_on": null, '
-                  u'"name": "Carl Perkins"}};\nwindow.carl.fields.created_on '
+        output = (u'<script>\nwindow.carl = {"fields": {"created_on": null, '
+                  u'"name": "Carl Perkins"}, '
+                  u'"model": "tests.silicamodelthingy", '
+                  u'"pk": null};\nwindow.carl.fields.created_on '
                   u'= new Date(window.carl.fields.created_on);\n</script>\n')
         self.tag_test(template, context, output)
 

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -132,7 +132,3 @@ class AngularInputFieldTagTests(TagHelper):
         # repeat test, with bound form
         my_form = SampleForm({'name': 'Joe Bloggs'})
         self.tag_test(template, context, output)
-
-
-def test_hello_world():
-    assert "hello_world" == "hello_world"

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -1,0 +1,137 @@
+
+from django import forms
+from django.db import models
+from django.test import TestCase
+from django.template import Context, Template
+from silica.django_app.models import BaseModel
+
+
+class Thingy(object):
+    """ a class for tests """
+    name = ""
+    description = ""
+
+    def __init__(self, name, description=""):
+        self.name = name
+        self.description = description
+
+
+class PlainModelThingy(models.Model):
+    """ a model for tests """
+    name = models.CharField()
+    created_on = models.DateTimeField(auto_now_add=True)
+
+
+class SilicaModelThingy(BaseModel):
+    """ a silica model for tests """
+    name = models.CharField()
+    created_on = models.DateTimeField(auto_now_add=True)
+
+
+class SampleForm(forms.Form):
+    """ a django form for tests """
+    name = forms.CharField(label='Your name', max_length=100)
+
+
+class TagHelper(TestCase):
+    """ base class for templatetag tests """
+
+    def tag_test(self, template, context, output):
+        t = Template('{% load silica %}'+template)
+        c = Context(context)
+        self.assertEqual(t.render(c), output)
+
+
+class FilterTagTests(TagHelper):
+    """ basic integration tests for django filter templatetags """
+
+    def test_getattr_tag(self):
+        thingy = Thingy(name=u"Ned")
+        template = "{{ thingy|getattr:'name' }}"
+        context = {'thingy': thingy}
+        output = u"Ned"
+        self.tag_test(template, context, output)
+
+    def test_getitem_tag(self):
+        thingy = {'name': u"Fred", 'label': u"Foo"}
+        template = "{{ thingy|getitem:'label' }}"
+        context = {'thingy': thingy}
+        output = u"Foo"
+        self.tag_test(template, context, output)
+
+    def test_title_space_tag(self):
+        template = "{{ title|title_space }}"
+        context = {'title': "Hi_There"}
+        output = u"Hi There"
+        self.tag_test(template, context, output)
+        # spaces are left intact
+        context = {'title': "Hello There"}
+        output = u"Hello There"
+        self.tag_test(template, context, output)
+        # String is expressed in title case
+        context = {'title': "HOW_are_yOu?"}
+        output = u"How Are You?"
+        self.tag_test(template, context, output)
+
+    def test_get_django_field_tag(self):
+        # TODO test different field types
+        thingy = SilicaModelThingy(name="Wood chip")
+        template = "{{ thingy|get_django_field:'name' }}"
+        context = {'thingy': thingy}
+        output = u"Wood chip"
+        self.tag_test(template, context, output)
+
+
+class AngularModelTagTests(TagHelper):
+    """ basic integration tests for angular_model tag """
+
+    def test_empty_model_renders_empty(self):
+        template = "{% angular_model model model_name params %}"
+        context = {'model_name': 'larry', 'model': None}
+        output = "<script>\nwindow.larry = {};\n</script>\n"
+        self.tag_test(template, context, output)
+
+    def test_ordinary_model_raises_exception(self):
+        thingy = PlainModelThingy(name="Carl Perkins")
+        template = "{% angular_model model model_name params %}"
+        context = {'model_name': 'carl', 'model': thingy}
+        output = "<script>\nwindow.carl = {};\n</script>\n"
+        # TODO: is this the appropriate behavior?
+        with self.assertRaises(AttributeError):
+            self.tag_test(template, context, output)
+
+    def test_silica_model_renders_correctly(self):
+        # TODO: use a more complex model here
+        # TODO: add unit tests for the BaseModel.to_json method
+        thingy = SilicaModelThingy(name="Carl Perkins")
+        template = "{% angular_model model model_name params %}"
+        context = {'model_name': 'carl', 'model': thingy}
+        output = (u'<script>\nwindow.carl = {"pk": null, "model": '
+                  u'"tests.silicamodelthingy", "fields": {"created_on": null, '
+                  u'"name": "Carl Perkins"}};\nwindow.carl.fields.created_on '
+                  u'= new Date(window.carl.fields.created_on);\n</script>\n')
+        self.tag_test(template, context, output)
+
+
+class AngularInputFieldTagTests(TagHelper):
+    """ basic integration tests for angular_input_field tag """
+    # TODO: add unit tests
+    # TODO: test unbound form and other edge cases
+
+    def test_angular_input_field(self):
+        my_form = SampleForm()
+        template = u'{% angular_input_field my_form.name model_name params %}'
+        context = {'my_form': my_form,
+                   'model_name': 'yourname',
+                   'params': {}}
+        output = (u'<input class="form-control" id="id_name" maxlength="100" '
+                  u'name="name" ng-model="yourname.fields.name" '
+                  u'required="true" type="text" />')
+        self.tag_test(template, context, output)
+        # repeat test, with bound form
+        my_form = SampleForm({'name': 'Joe Bloggs'})
+        self.tag_test(template, context, output)
+
+
+def test_hello_world():
+    assert "hello_world" == "hello_world"

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -1,5 +1,6 @@
 
 from django import forms
+from django import VERSION
 from django.db import models
 from django.test import TestCase
 from django.template import Context, Template
@@ -125,9 +126,15 @@ class AngularInputFieldTagTests(TagHelper):
         context = {'my_form': my_form,
                    'model_name': 'yourname',
                    'params': {}}
-        output = (u'<input class="form-control" id="id_name" maxlength="100" '
-                  u'name="name" ng-model="yourname.fields.name" '
-                  u'required="true" type="text" />')
+        # Django 1.10 changes the rendering of boolean attributes
+        if VERSION[1] > 9:
+            output = (u'<input class="form-control" id="id_name" '
+                      u'maxlength="100" name="name" ng-model='
+                      u'"yourname.fields.name" type="text" required />')
+        else:
+            output = (u'<input class="form-control" id="id_name" '
+                      u'maxlength="100" name="name" ng-model='
+                      u'"yourname.fields.name" required="true" type="text" />')
         self.tag_test(template, context, output)
         # repeat test, with bound form
         my_form = SampleForm({'name': 'Joe Bloggs'})

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+# NOTE: Python 2.5 not supported by tox
+# NOTE: Python 2.6 not supported by Django 1.8+
+envlist = py27-django{18,19}
+
+[testenv]
+deps =
+  django18: Django>=1.8,<1.9
+  django19: Django>=1.9
+  pytest
+  pytest-django
+commands=
+  py.test \
+        {posargs}
+setenv =
+    PYTHONPATH = {toxinidir}

--- a/tox.ini
+++ b/tox.ini
@@ -7,10 +7,4 @@ envlist = py27-django{18,19}
 deps =
   django18: Django>=1.8,<1.9
   django19: Django>=1.9
-  pytest
-  pytest-django
-commands=
-  py.test \
-        {posargs}
-setenv =
-    PYTHONPATH = {toxinidir}
+commands = python setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
 # NOTE: Python 2.5 not supported by tox
 # NOTE: Python 2.6 not supported by Django 1.8+
-envlist = py27-django{18,19}
+envlist = py27-django{19,110}
 
 [testenv]
 deps =
   django18: Django>=1.8,<1.9
   django19: Django>=1.9
+  django110: Django==1.10a1
 commands = python setup.py test


### PR DESCRIPTION
Set up a basic test framework, including an initial set of tests.
- Tests are written using Django test framework.
- Includes basic integration tests for all custom template tags.
- Includes tox config for testing with multiple versions of Python and Django.

To run the tests, use the command:

```
python setup.py test
```

To use tox, make sure it is installed:

```
pip install tox
```

then run the tests, using the command:

   tox

Note: all required Python versions must be available on the test system for tox to work. Currently, the code only supports Python 2.7.x., but support for 3.x should be added in the future.
## FUTURE
- add more tests.
- consider adding support for Django 1.8.
- incorporate AngularJS tests to fully validate generated code.
- support Python 3.
- add more tests.
